### PR TITLE
Fix homebrew formula publishing to use Formula directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,13 +145,16 @@ jobs:
           # Clone the tap repository
           git clone https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/jsando/homebrew-tools.git
           
-          # Update the formula (formulas are in root directory)
-          cp mpu.rb homebrew-tools/
+          # Create Formula directory if it doesn't exist
+          mkdir -p homebrew-tools/Formula
+          
+          # Update the formula in Formula directory
+          cp mpu.rb homebrew-tools/Formula/
           
           # Commit and push
           cd homebrew-tools
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add mpu.rb
+          git add Formula/mpu.rb
           git commit -m "Brew formula update for mpu version ${{ github.ref_name }}"
           git push


### PR DESCRIPTION
## Summary
- Update release workflow to publish mpu.rb to the Formula subdirectory instead of root directory

## Problem
The homebrew package is no longer found because another project has published to the Formula folder in jsando/homebrew-tools, and the mpu formula was being published to the root directory.

## Solution
- Modified the release workflow to create the Formula directory if it doesn't exist
- Changed the copy destination to `homebrew-tools/Formula/`
- Updated the git add command to use the correct path

This change ensures the mpu formula is published to the standard Homebrew tap location.

## Test plan
The changes will be tested when the next release is created.

🤖 Generated with [Claude Code](https://claude.ai/code)