### PR TITLE
Fix Homebrew linking issues when installing with dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,11 @@ jobs:
               (pkgshare/"examples").install Dir["examples/*"]
             end
           
+            def post_install
+              # Ensure the binary is executable
+              (bin/"mpu").chmod 0755
+            end
+          
             def caveats
               <<~EOS
                 Example programs have been installed to:
@@ -133,6 +138,9 @@ jobs:
                 
                 For more information, see:
                   #{HOMEBREW_PREFIX}/share/doc/mpu/README.md
+                
+                If 'mpu' command is not found after installation, run:
+                  brew link mpu
               EOS
             end
           


### PR DESCRIPTION
## Summary
- Add post_install hook to ensure proper binary permissions
- Add brew link instruction to caveats for users who encounter the "command not found" issue

## Problem
When installing mpu on a machine without pre-installed SDL2 dependencies, Homebrew installs all dependencies (sdl2, sdl2_image, sdl2_mixer, sdl2_ttf, sdl2_gfx) as part of the installation process. This can trigger Homebrew's "broken linkage" detection, causing it to reinstall mpu but fail to properly link the binary to PATH.

Users then see "command not found: mpu" and need to manually run:
- `brew cleanup`
- `brew link mpu`

## Solution
1. Added a `post_install` hook that ensures the binary has correct permissions (755)
2. Updated the caveats to include instructions for users who encounter the linking issue

This provides both a potential fix and clear instructions for the workaround.

## Test plan
The changes will be tested with the next release when users install on fresh systems without SDL2 dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)