### PR TITLE
Improve label syntax consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,15 +658,17 @@ For example to declare a global variable 'MyVar' that holds a word, with initial
 MyVar:  dw 5            // Emits bytes 0x05 0x00
 ```
 
-## Import
+## include
 
-Use the 'import' directive to append another assembly source file to the end of the current one, if it hasn't already been included.  It is like 'include' except it always appends the given path after processing the current source file.
+Use the 'include' directive to append another assembly source file to the end of the current one, if it hasn't already been included.  It always appends the given path after processing the current source file.
+
+Paths are resolved relative to the current file.
 
 Example:
 
 ```
-    import "strconv.s"
-    import "random.s"
+    include "strconv.s"
+    include "random.s"
 ```
 
 ## Assembly Grammar
@@ -674,23 +676,23 @@ Example:
 line :=
         label
     |   label instruction
+    |   equate
     |   instruction
     |   function
     |   test
-    |   equate
     |   vardecl
-    |   import
+    |   include
 
-import :=
-        'import' string
+include :=
+        'include' "path"
 
 label := 
         ident ':'
-    |   .ident
+    |   '.' ident ':'
 
 equate := 
         ident '=' expr
-    |   .ident '=' expr
+    |   '.' ident '=' expr
 
 function :=
         ident '(' param-list ')' ':'

--- a/README.md
+++ b/README.md
@@ -556,14 +556,25 @@ my-label:
 
 Local labels are prefixed with '.' and are scoped to the previous symbol.  This means they are only visible until the next global symbol is defined, and it means the same local label can be reused.
 
-```
-foo:
-.loop:
-.exit:
+See how both of these subroutines reuse "loop" as a label.  Also note when you reference a local label you don't use the dot, meaning you declare it as ".loop:" but refer to it still just as "loop".
 
-bar:
+```
+counter:    dw 0
+
+count_down_from_ten:
+        cpy counter, #10
 .loop:
-.exit:
+        dec counter
+        jne loop
+        ret
+
+count_to_ten:
+        cpy counter, #0
+.loop:
+        inc counter
+        cmp counter, #10
+        jlt loop
+        ret
 ```
 
 ## Functions & Variables

--- a/README.md
+++ b/README.md
@@ -670,7 +670,6 @@ Example:
     include "strconv.s"
     include "random.s"
 ```
-
 ## Assembly Grammar
 
 line :=
@@ -680,50 +679,78 @@ line :=
     |   instruction
     |   function
     |   test
-    |   vardecl
+    |   variable_declaration
+    |   directive
     |   include
 
 include :=
         'include' "path"
 
-label := 
-        ident ':'
-    |   '.' ident ':'
+label :=
+        identifier ':'
+    |   '.' identifier ':'
 
-equate := 
-        ident '=' expr
-    |   '.' ident '=' expr
+equate :=
+        identifier '=' expr
+    |   '.' identifier '=' expr
 
 function :=
-        ident '(' param-list ')' ':'
+        identifier '(' param-list ')' ':'
 
 test :=
-        'test' ident '(' ')' ':'
+        'test' identifier '(' ')' ':'
 
-vardecl :=
-        'var' ident ['byte' | 'word']
+variable_declaration :=
+        'var' identifier ['byte' | 'word']
+
+directive :=
+        'org' expr
+        |   'db' expr-list
+        |   'dw' expr-list
+        |   'ds' expr
 
 instruction :=
-        keyword [operand[,operand]*]
+        opcode [operand [,operand]*]
 
-Operand  :=
+operand  :=
       '#' expr
     | '*' expr
     | expr
 
 expr :=
-    MulExpr [ ('+' | '-' | '|' | '^') MulExpr]*
+    mul-expr [ ('+' | '-' | '|' | '^') mul-expr]*
 
-MulExpr :=
-    UnaryExpr ['*' | '/' | '%' | '<<' | '>>'  UnaryExpr]*
+mul-expr :=
+    unary-expr ['*' | '/' | '%' | '<<' | '>>'  unary-expr]*
 
-UnaryExpr :=
-    ['+' | '-'] PrimaryExpr
+unary-expr :=
+    ['+' | '-'] primary-expr
 
-PrimaryExpr :=
+primary-expr :=
       '(' expr ')'
-    | Identifier
-    | Literal (int, String, Char)
+    | identifier
+    | integer
+    | string
+    | char
+
+expr-list :=
+    expr [',' expr]*
+
+comment := '//' {any-char} newline
+
+identifier := letter {letter | digit | '-' | '_'}
+
+integer := decimal-literal | hex-literal | binary-literal | char-literal
+
+decimal-literal := digit {digit | '_'}
+
+hex-literal := '0x' hex-digit {hex-digit | '_'}
+
+binary-literal := '0b' ('0' | '1') {('0' | '1') | '_'}
+
+char-literal := "'" char "'"
+
+string := '"' {string-char} '"'
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -558,12 +558,12 @@ Local labels are prefixed with '.' and are scoped to the previous symbol.  This 
 
 ```
 foo:
-.loop
-.exit
+.loop:
+.exit:
 
 bar:
-.loop
-.exit
+.loop:
+.exit:
 ```
 
 ## Functions & Variables

--- a/asm/lexer.go
+++ b/asm/lexer.go
@@ -83,7 +83,7 @@ const (
 	TokHlt
 	TokSea
 	TokFunction
-	TokImport
+	TokInclude
 	TokVar
 	TokTest
 	TokComment
@@ -104,7 +104,7 @@ var tokenImage = []string{
 	"jlt", "inc", "dec", "jsr", "ret",
 	"clc", "sec", "clb", "seb", "jcc",
 	"jcs", "sav", "rst", "hlt", "sea",
-	"function()", "import", "var", "test",
+	"function()", "include", "var", "test",
 	"<comment>", "<eol>",
 }
 
@@ -128,13 +128,13 @@ type TokenReader interface {
 // in order because the first source file will establish the org,
 // all others must be libraries with relocatable code.
 type Input struct {
-	tr      []TokenReader
-	imports map[string]bool
-	files   []string // file names, in the order they were processed
+	tr       []TokenReader
+	includes map[string]bool
+	files    []string // file names, in the order they were processed
 }
 
 func NewInput(readers []TokenReader) *Input {
-	inp := &Input{imports: make(map[string]bool)}
+	inp := &Input{includes: make(map[string]bool)}
 	for _, r := range readers {
 		inp.Append(r)
 	}
@@ -142,9 +142,9 @@ func NewInput(readers []TokenReader) *Input {
 }
 
 func (i *Input) Append(r TokenReader) {
-	if !i.imports[r.FileName()] {
+	if !i.includes[r.FileName()] {
 		i.tr = append(i.tr, r)
-		i.imports[r.FileName()] = true
+		i.includes[r.FileName()] = true
 		i.files = append(i.files, r.FileName())
 	}
 }

--- a/asm/linker.go
+++ b/asm/linker.go
@@ -71,7 +71,7 @@ func (l *Linker) Link() {
 			l.doDefineWord(t)
 		case *DefineSpaceStatement:
 			l.doDefineSpace(t)
-		case *ImportStatement:
+		case *IncludeStatement:
 			// nothing to do
 		case *OrgStatement:
 			l.doOrg(t)
@@ -323,7 +323,7 @@ func (l *Linker) doTest(test *TestStatement) {
 	// Test functions are just like regular functions but without parameters
 	// Define the test function label
 	l.defineLabel(test, test.name)
-	l.function = nil  // Tests don't have automatic fp handling like functions
+	l.function = nil // Tests don't have automatic fp handling like functions
 }
 
 func (l *Linker) doEmit2Operand(stmt *InstructionStatement) {
@@ -335,7 +335,7 @@ func (l *Linker) doEmit2Operand(stmt *InstructionStatement) {
 	op1 := stmt.operands[0]
 	op2 := stmt.operands[1]
 	op := tokToOp(stmt.operation)
-	
+
 	// Catch encoding errors and report them properly
 	var opCode byte
 	func() {
@@ -350,11 +350,11 @@ func (l *Linker) doEmit2Operand(stmt *InstructionStatement) {
 		}()
 		opCode = machine.EncodeOp(op, op1.mode, op2.mode)
 	}()
-	
+
 	if l.messages.errors > 0 {
 		return // Don't continue if we had an error
 	}
-	
+
 	l.writeByte(int(opCode))
 	l.resolveWordOperand(stmt, op1)
 	l.resolveWordOperand(stmt, op2)
@@ -375,7 +375,7 @@ func (l *Linker) doEmit1Operand(ins *InstructionStatement) {
 	if op == machine.Pop && op1.mode == machine.Immediate {
 		op1.mode = machine.ImmediateByte
 	}
-	
+
 	// Catch encoding errors and report them properly
 	var opCode byte
 	func() {
@@ -390,11 +390,11 @@ func (l *Linker) doEmit1Operand(ins *InstructionStatement) {
 		}()
 		opCode = machine.EncodeOp(op, op1.mode, machine.Implied)
 	}()
-	
+
 	if l.messages.errors > 0 {
 		return // Don't continue if we had an error
 	}
-	
+
 	l.writeByte(int(opCode))
 	l.resolveWordOperand(ins, op1)
 }

--- a/asm/linker_test.go
+++ b/asm/linker_test.go
@@ -74,7 +74,7 @@ a:		dw 0
 	assert.False(t, linker.HasErrors())
 
 	debugInfo := linker.DebugInfo()
-	
+
 	// Find debug info for each instruction
 	var clcInfo, seaInfo, cmpInfo *DebugInfo
 	for i := range debugInfo {

--- a/asm/message.go
+++ b/asm/message.go
@@ -26,8 +26,8 @@ const (
 type Message struct {
 	messageType int
 	file        string
-	line        int    // 1-based line number
-	column      int    // 1-based column number
+	line        int // 1-based line number
+	column      int // 1-based column number
 	message     string
 }
 

--- a/asm/parser.go
+++ b/asm/parser.go
@@ -26,23 +26,23 @@ import (
 )
 
 type Parser struct {
-	messages      *Messages
-	lexer         *Input
-	pc            int
-	first         Statement
-	last          Statement
-	eolCount      int                // to remember intentional blank lines for reformat
-	comments      []string           // pending block comments for next statement
-	processImport bool               // If just formatting don't automatically append imports
-	function      *FunctionStatement // Current function to append vars to or nil
-	global        string             // Most recent global (function or label), to define locals against
+	messages       *Messages
+	lexer          *Input
+	pc             int
+	first          Statement
+	last           Statement
+	eolCount       int                // to remember intentional blank lines for reformat
+	comments       []string           // pending block comments for next statement
+	processInclude bool               // If just formatting don't automatically append includes
+	function       *FunctionStatement // Current function to append vars to or nil
+	global         string             // Most recent global (function or label), to define locals against
 }
 
 func NewParser(lex *Input) *Parser {
 	return &Parser{
-		messages:      &Messages{},
-		lexer:         lex,
-		processImport: true,
+		messages:       &Messages{},
+		lexer:          lex,
+		processInclude: true,
 	}
 }
 
@@ -50,8 +50,8 @@ func NewParserFromReader(name string, r io.Reader) *Parser {
 	return NewParser(NewInput([]TokenReader{NewLexer(name, r)}))
 }
 
-func (p *Parser) SetProcessImport(process bool) {
-	p.processImport = process
+func (p *Parser) SetProcessInclude(process bool) {
+	p.processInclude = process
 }
 
 // Files returns the list of all files processed.
@@ -200,8 +200,8 @@ loop:
 			switch tok {
 			case TokIdent:
 				p.parseGlobalSymbol() // global label, equate, or function
-			case TokImport:
-				p.parseImports()
+			case TokInclude:
+				p.parseIncludes()
 			case TokTest:
 				p.parseTestDecl()
 			case TokDb:
@@ -227,12 +227,12 @@ loop:
 	}
 }
 
-func (p *Parser) parseImports() {
-	stmt := &ImportStatement{}
+func (p *Parser) parseIncludes() {
+	stmt := &IncludeStatement{}
 	p.addStatement(stmt)
 	tok := p.lexer.Next()
 	if tok != TokString {
-		p.errorf("imports requires string as argument")
+		p.errorf("includes requires string as argument")
 		return
 	}
 	name, err := strconv.Unquote(p.lexer.TokenText())
@@ -244,9 +244,9 @@ func (p *Parser) parseImports() {
 
 	// When running fmt we don't want to append all included files to the one original file :)
 	// Just need the AST to reformat the code.
-	if p.processImport {
+	if p.processInclude {
 		dir := filepath.Dir(p.lexer.FileName())
-		name = filepath.Join(dir, name) + ".s"
+		name = filepath.Join(dir, name)
 		file, err := os.Open(name)
 		if err != nil {
 			p.errorf("error opening file '%s': %s\n", name, err.Error())
@@ -346,37 +346,37 @@ func (p *Parser) parseTestDecl() {
 		p.skipToEOL()
 		return
 	}
-	
+
 	testName := p.lexer.TokenText()
-	
+
 	if p.lexer.Next() != TokLeftParen {
 		p.errorf("expected '(' after test function name")
 		p.skipToEOL()
 		return
 	}
-	
+
 	if p.lexer.Next() != TokRightParen {
 		p.errorf("expected ')' - test functions take no parameters")
 		p.skipToEOL()
 		return
 	}
-	
+
 	if p.lexer.Next() != TokColon {
 		p.errorf("expected ':' after test function declaration")
 		p.skipToEOL()
 		return
 	}
-	
+
 	// Create test statement
 	test := &TestStatement{
 		name: testName,
 	}
 	p.addStatement(test)
-	
+
 	// Set this as the current global context
 	p.global = testName
 	p.function = nil
-	
+
 	p.lexer.Next()
 }
 
@@ -617,10 +617,11 @@ func (p *Parser) parseUnaryExpr() Expr {
 	}
 }
 
-//PrimaryExpr :=
-//      '(' origin ')'
-//    | Identifier
-//    | Literal (int, String, Char)
+// PrimaryExpr :=
+//
+//	  '(' origin ')'
+//	| Identifier
+//	| Literal (int, String, Char)
 func (p *Parser) parsePrimaryExpr() Expr {
 	var expr Expr
 	switch p.lexer.Token() {

--- a/asm/parser.go
+++ b/asm/parser.go
@@ -391,6 +391,8 @@ func (p *Parser) parseLocalSymbol() {
 		p.skipToEOL()
 		return
 	}
+	text := p.lexer.TokenText()
+	line := p.lexer.Line()
 	id := p.global + "." + p.lexer.TokenText()
 	p.lexer.Next()
 
@@ -401,11 +403,17 @@ func (p *Parser) parseLocalSymbol() {
 		p.addStatement(stmt)
 		p.lexer.Next()
 		stmt.value = p.parseExpr()
-	} else {
+	} else if p.lexer.Token() == TokColon {
 		stmt := &LabelStatement{
 			name: id,
 		}
 		p.addStatement(stmt)
+		p.lexer.Next()
+	} else {
+		// Report error at the saved line number
+		p.errorAtf(line, "expected '=' or ':' after identifier '%s'", text)
+		// Skip to end of line for error recovery
+		p.skipToEOL()
 	}
 }
 

--- a/asm/parser_test.go
+++ b/asm/parser_test.go
@@ -82,11 +82,11 @@ clc`,
 		t.Run(tt.name, func(t *testing.T) {
 			parser := NewParserFromReader("test", strings.NewReader(tt.input))
 			parser.Parse()
-			
+
 			if parser.messages.errors == 0 {
 				t.Fatal("expected an error but got none")
 			}
-			
+
 			// Check that the error is on the correct line
 			foundCorrectLine := false
 			for _, msg := range parser.messages.messages {
@@ -100,7 +100,7 @@ clc`,
 					}
 				}
 			}
-			
+
 			if !foundCorrectLine {
 				t.Errorf("did not find error on line %d", tt.wantLine)
 			}
@@ -118,11 +118,11 @@ test MyTest():
 `
 	parser := NewParserFromReader("test", strings.NewReader(source))
 	parser.Parse()
-	
+
 	if parser.messages.errors != 0 {
 		t.Fatalf("expected no errors, got %d", parser.messages.errors)
 	}
-	
+
 	// Find the test statement
 	var testStmt *TestStatement
 	for s := parser.Statements(); s != nil; s = s.Next() {
@@ -131,11 +131,11 @@ test MyTest():
 			break
 		}
 	}
-	
+
 	if testStmt == nil {
 		t.Fatal("expected to find TestStatement")
 	}
-	
+
 	if testStmt.name != "MyTest" {
 		t.Errorf("expected test name 'MyTest', got '%s'", testStmt.name)
 	}
@@ -150,11 +150,11 @@ myFunc(a word, b word):
 `
 	parser := NewParserFromReader("test", strings.NewReader(source))
 	parser.Parse()
-	
+
 	if parser.messages.errors != 0 {
 		t.Fatalf("expected no errors, got %d", parser.messages.errors)
 	}
-	
+
 	// Find the function statement
 	var fnStmt *FunctionStatement
 	for s := parser.Statements(); s != nil; s = s.Next() {
@@ -163,11 +163,11 @@ myFunc(a word, b word):
 			break
 		}
 	}
-	
+
 	if fnStmt == nil {
 		t.Fatal("expected to find FunctionStatement")
 	}
-	
+
 	if fnStmt.name != "myFunc" {
 		t.Errorf("expected function name 'myFunc', got '%s'", fnStmt.name)
 	}
@@ -189,11 +189,11 @@ test TestMyFunc():
 `
 	parser := NewParserFromReader("test", strings.NewReader(source))
 	parser.Parse()
-	
+
 	if parser.messages.errors != 0 {
 		t.Fatalf("expected no errors, got %d", parser.messages.errors)
 	}
-	
+
 	// Count statements
 	var fnCount, testCount int
 	for s := parser.Statements(); s != nil; s = s.Next() {
@@ -204,11 +204,11 @@ test TestMyFunc():
 			testCount++
 		}
 	}
-	
+
 	if fnCount != 1 {
 		t.Errorf("expected 1 function, got %d", fnCount)
 	}
-	
+
 	if testCount != 1 {
 		t.Errorf("expected 1 test, got %d", testCount)
 	}

--- a/asm/printer.go
+++ b/asm/printer.go
@@ -81,9 +81,9 @@ func (p *Printer) Print(stmt Statement) {
 			p.tab(OpColumn)
 			p.print("ds ")
 			p.expr(t.size)
-		case *ImportStatement:
+		case *IncludeStatement:
 			p.tab(OpColumn)
-			p.printf("import \"%s\"", t.path)
+			p.printf("include \"%s\"", t.path)
 		case *OrgStatement:
 			p.tab(OpColumn)
 			p.print("org ")
@@ -106,6 +106,8 @@ func (p *Printer) Print(stmt Statement) {
 				count++
 			}
 			p.printf("):")
+		case *TestStatement:
+			p.printf("%s():", t.name)
 		case *VarStatement:
 			p.tab(OpColumn)
 			p.printf("var %s %s", toLocal(t.name), wordOrByte(t.size))

--- a/asm/printer.go
+++ b/asm/printer.go
@@ -29,7 +29,7 @@ type Printer struct {
 }
 
 const (
-	OpColumn      = 16
+	OpColumn      = 12
 	CommentColumn = 32
 )
 
@@ -147,7 +147,7 @@ func (p *Printer) label(label string) {
 	if loc == label {
 		loc += ":"
 	} else {
-		loc = "." + loc
+		loc = "." + loc + ":"
 	}
 	p.print(loc)
 }
@@ -216,11 +216,13 @@ func (p *Printer) tab(column int) {
 }
 
 func (p *Printer) stmt(stmt *InstructionStatement) {
-	p.printf("%s ", stmt.operation)
+	p.printf("%s", stmt.operation)
 	count := 0
 	for _, op := range stmt.operands {
 		if count > 0 {
-			p.printf(",")
+			p.printf(", ")
+		} else {
+			p.print(" ")
 		}
 		switch op.mode {
 		case machine.Implied:

--- a/asm/statement.go
+++ b/asm/statement.go
@@ -84,7 +84,7 @@ type (
 		origin Expr
 	}
 
-	ImportStatement struct {
+	IncludeStatement struct {
 		Node
 		path string
 	}

--- a/example/ball.s
+++ b/example/ball.s
@@ -3,9 +3,9 @@
 // dx/dy as vectors with a separate speed, and normalizing
 // the vector.
 
-            import "random"
-            import "stdio"
-            import "sqrt"
+            include "random.s"
+            include "stdio.s"
+            include "sqrt.s"
 
             org 0
 REG_PC:     dw main

--- a/example/ball.s
+++ b/example/ball.s
@@ -46,12 +46,12 @@ main():
             // Open the main window
             jsr InitScreen
             jsr InitBall
-.loop
+.loop:
             jsr PollEvents
             jsr DrawScreen
             cmp quit, #0
             jeq loop
-.exit        
+.exit:
             // Main doesn't return, it just halts.
             hlt
 
@@ -62,47 +62,47 @@ InitScreen():
             cpy REG_IO_REQ, #init
             ret
 
-.init       dw 0x0201
+.init:       dw 0x0201
             dw SCREEN_WIDTH
             dw SCREEN_HEIGHT
             dw title
-.title      db "BALL", 0
+.title:      db "BALL", 0
 
 //
 // Poll and handle all pending graphics events, return 1 if time to exit.
 //
 PollEvents():
-.loop
+.loop:
             cpy REG_IO_REQ, #poll
             cmp poll_event, #SDL_QUIT
             jne isKeyDown
             cpy quit, #1
             jmp exit
-.isKeyDown
+.isKeyDown:
             cmp poll_event, #SDL_KEYDOWN
             jne isKeyUp
             psh keycode
             jsr onKeyDown
             pop #2
             jmp loop
-.isKeyUp
+.isKeyUp:
             cmp poll_event, #SDL_KEYUP
             jne isNoMore
             psh keycode
             jsr onKeyUp
             pop #2
             jmp loop
-.isNoMore
+.isNoMore:
             cmp poll_event, #0
             jne loop
-.exit            
+.exit:
             ret
 
-.poll       dw 0x0202           // graphics, poll        
-.poll_event dw 0                // space for response event type id
-.poll_time  dw 0                // space for response event timestamp (1/4 second since init)
-.keycode
-.poll_data  ds 8                // space for response, structure depends on event type
+.poll:       dw 0x0202           // graphics, poll
+.poll_event: dw 0                // space for response event type id
+.poll_time:  dw 0                // space for response event timestamp (1/4 second since init)
+.keycode:
+.poll_data:  ds 8                // space for response, structure depends on event type
 
 //
 // Handle keydown events.
@@ -111,7 +111,7 @@ onKeyDown(keycode word):
             cmp keycode, #SDLK_ESCAPE
             jne done
             cpy quit, #1
-.done            
+.done:
             ret
 
 //
@@ -132,21 +132,21 @@ DrawScreen():
             ret
 
             // device request to set color
-.color      dw 0x0205
-.color_r    db 0
-.color_g    db 0
-.color_b    db 0
-.color_a    db 255
+.color:      dw 0x0205
+.color_r:    db 0
+.color_g:    db 0
+.color_b:    db 0
+.color_a:    db 255
 
             // device request to clear screen
-.clear      dw 0x0204
+.clear:      dw 0x0204
 
             // device request to present backbuffer to screen
-.present    dw 0x0203
+.present:    dw 0x0203
             dw 10               // delay ms
-.white      dw 0x0205
+.white:      dw 0x0205
             db 255,255,255,255
-.line       dw 0x0206
+.line:       dw 0x0206
             dw SCREEN_WIDTH / 2
             dw 0
             dw SCREEN_WIDTH / 2
@@ -221,7 +221,7 @@ BallVectNormalize():
             cpy length, t1
             mul ball_dx, length
             mul ball_dy, length
-.done
+.done:
             ret
 
 //
@@ -245,17 +245,17 @@ DrawBall():
             jlt y_bounce
             cmp ball_y, #(SCREEN_HEIGHT - BALL_RADIUS)
             jlt y_no_bounce
-.y_bounce
+.y_bounce:
             mul ball_dy, #-1
-.y_no_bounce
+.y_no_bounce:
             // If ball off screen, re-initialize
             cmp ball_x, #-BALL_RADIUS
             jlt x_bounce
             cmp ball_x, #SCREEN_WIDTH
             jlt no_reset
-.x_bounce
+.x_bounce:
             mul ball_dx, #-1
-.no_reset            
+.no_reset:
             // ball_x += ball_dx * ball_speed
             cpy t1, ball_dx
             mul t1, ball_speed            
@@ -275,13 +275,13 @@ DrawBall():
             ret
 
             // device request to set color
-.color      dw 0x0205
+.color:      dw 0x0205
             db 255,255,255,255
 
             // device request to fill rectangle
-.rect       dw 0x0208
-.rect_x     dw 100
-.rect_y     dw 100
-.rect_w     dw 50
-.rect_h     dw 50
+.rect:       dw 0x0208
+.rect_x:     dw 100
+.rect_y:     dw 100
+.rect_w:     dw 50
+.rect_h:     dw 50
 

--- a/example/blocks.s
+++ b/example/blocks.s
@@ -14,10 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-            import "random"
-            import "lcd"
-            import "stdio"
-            import "strconv"
+            include "random.s"
+            include "lcd.s"
+            include "stdio.s"
+            include "strconv.s"
 
             org 0
             dw Main

--- a/example/blocks.s
+++ b/example/blocks.s
@@ -149,7 +149,7 @@ WavNewGame:     db "wav/win-00.wav",0
 
 DebugHere:  dw 0x0101           // Quick way to trace execution by printing stuff :)
             dw buffer
-.buffer     db "here\n",0
+.buffer:     db "here\n",0
 
 LineScoreTable:
             dw 0, 100, 200, 500, 2000
@@ -213,7 +213,7 @@ ResetEnd:
 Main():
             jsr InitScreen
             jsr NewGame
-.loop
+.loop:
             jsr PollEvents
             jsr DrawScreen
             cmp QuitFlag, #0
@@ -235,84 +235,84 @@ InitScreen():
             cpy IO_REQUEST, #loadWav
             ret
 
-.init       dw 0x0201
+.init:       dw 0x0201
             dw SCREEN_WIDTH
             dw SCREEN_HEIGHT
             dw title
-.title      db "MPU Blocks", 0
-.initAudio  dw 0x020a
-.loadWav    dw 0x020b
-.wavptr     dw 0
+.title:      db "MPU Blocks", 0
+.initAudio:  dw 0x020a
+.loadWav:    dw 0x020b
+.wavptr:     dw 0
 
 PollEvents():
-.loop
+.loop:
             cpy IO_REQUEST, #poll
             cmp poll_event, #SDL_QUIT
             jne isKeyDown
             cpy QuitFlag, #1
             jmp exit
-.isKeyDown
+.isKeyDown:
             cmp poll_event, #SDL_KEYDOWN
             jne isKeyUp
             psh keycode
             jsr OnKeyDown
             pop #2
             jmp loop
-.isKeyUp
+.isKeyUp:
             cmp poll_event, #SDL_KEYUP
             jne isNoMore
             psh keycode
             jsr OnKeyUp
             pop #2
             jmp loop
-.isNoMore
+.isNoMore:
             cmp poll_event, #0
             jne loop
 
             cmp KeyEscDown, #1
             jne exit
             cpy QuitFlag, #1
-.exit            
+.exit:
             ret
 
-.poll       dw 0x0202           
-.poll_event dw 0                
-.poll_time  dw 0                
-.keycode
-.poll_data  ds 8                
+.poll:       dw 0x0202
+.poll_event:dw 0
+.poll_time:  dw 0
+.keycode:
+.poll_data: ds 8
 
 OnKeyDown(keycode word):
             var tabptr word
 
             cpy tabptr, #KeyTable
-.loop            
+.loop:
             cmp *tabptr, #0
             jeq done
             cmp *tabptr, keycode
             jeq keyFound
             add tabptr, #4
             jmp loop
-.keyFound
+.keyFound:
             add tabptr, #2
             cpy *tabptr, #1
-.done
+.done:
             ret
 
 OnKeyUp(keycode word):
             var tabptr word
 
             cpy tabptr, #KeyTable
-.loop            
+.loop:
             cmp *tabptr, #0
             jeq done
             cmp *tabptr, keycode
             jeq keyFound
             add tabptr, #4
             jmp loop
-.keyFound
+.keyFound:
             add tabptr, #2
             cpy *tabptr, #0
-.done
+.done:
             ret
 
 DrawScreen():
@@ -333,17 +333,17 @@ DrawScreen():
             jsr CreatePiece
             cmp Piece, #255
             jeq showGameOver
-.noNewPiece
+.noNewPiece:
             jsr DrawPieces
             jsr UpdateGame
             jmp done
-.showGameOver
+.showGameOver:
             // In game-over mode
             cmp OutroFlag, #0
             jeq drawGameOver
             cpy OutroFlag, #0
             cpy IO_REQUEST, #gameOverSound
-.drawGameOver
+.drawGameOver:
             cpy IO_REQUEST, #ColorWhite
             cpy tx, #GameOverX
             cpy ty, #GameOverY
@@ -353,28 +353,28 @@ DrawScreen():
             cmp KeySpaceDown, #1
             jne done
             jsr NewGame
-.done            
+.done:
             cpy IO_REQUEST, #present
             ret
 
             // device request to clear screen
-.clear      dw 0x0204
+.clear:      dw 0x0204
 
             // device request to present backbuffer to screen
-.present    dw 0x0203
+.present:    dw 0x0203
             dw 10               // delay ms
 
-.boardRect  dw 0x0208
+.boardRect:  dw 0x0208
             dw BOARD_X + CELL_SIZE / 2
             dw BOARD_Y + CELL_SIZE / 2
             dw BOARD_WIDTH - CELL_SIZE - 1
             dw BOARD_HEIGHT - CELL_SIZE - 1
-.boardRect2  dw 0x0207
+.boardRect2:  dw 0x0207
             dw BOARD_X + CELL_SIZE / 2
             dw BOARD_Y + CELL_SIZE / 2
             dw BOARD_WIDTH - CELL_SIZE - 1
             dw BOARD_HEIGHT - CELL_SIZE - 1
-.gameOverSound  dw 0x020c
+.gameOverSound:  dw 0x020c
             dw WavGameOver
 
 DrawScore():
@@ -427,21 +427,21 @@ DrawScore():
 .lines_y     = level_y + LCD_LINE_SPACE + 5
 .score_y     = lines_y + LCD_LINE_SPACE + 5
 
-.level_string   db  "LEVEL ",0
-.lines_string   db  "LINES ",0
-.score_string   db  "SCORE ",0
+.level_string:   db  "LEVEL ",0
+.lines_string:   db  "LINES ",0
+.score_string:   db  "SCORE ",0
 
-.level_rect dw 0x0208
+.level_rect: dw 0x0208
             dw text_x - 10
             dw level_y - 3
             dw 12 * LCD_CHAR_SPACE
             dw LCD_LINE_SPACE
-.lines_rect dw 0x0208
+.lines_rect: dw 0x0208
             dw text_x - 10
             dw lines_y - 3
             dw 12 * LCD_CHAR_SPACE
             dw LCD_LINE_SPACE
-.score_rect dw 0x0208
+.score_rect: dw 0x0208
             dw text_x - 10
             dw score_y - 3
             dw 12 * LCD_CHAR_SPACE
@@ -455,7 +455,7 @@ Draw5Digit(value word):
 
             cpy first, #0
             cpy divisor, #10000
-.loop
+.loop:
             cpy t1, value
             div t1, divisor
             cpy t2, t1
@@ -470,10 +470,10 @@ Draw5Digit(value word):
             jne fgColor
             cpy IO_REQUEST, #ColorGrey
             jmp printChar
-.fgColor
+.fgColor:
             cpy first, #1
             cpy IO_REQUEST, #ColorScoreFG
-.printChar
+.printChar:
             add t1, #0x10
             psh t1
             jsr DrawCharacter
@@ -483,7 +483,7 @@ Draw5Digit(value word):
             jeq done
             div divisor, #10
             jne loop
-.done
+.done:
             ret
 
 DrawBoard():
@@ -496,9 +496,9 @@ DrawBoard():
             var t1 word
 
             cpy i, #1
-.iLoop
+.iLoop:
             cpy j, #4
-.jLoop
+.jLoop:
             cpy x, i
             mul x, #CELL_SIZE
             add x, #BOARD_X
@@ -533,9 +533,9 @@ DrawBoard():
             jlt iLoop
             ret
 
-.fillRect   dw 0x0208
-.fillX      dw 0
-.fillY      dw 0
+.fillRect:   dw 0x0208
+.fillX:      dw 0
+.fillY:      dw 0
             dw CELL_SIZE-2
             dw CELL_SIZE-2
 
@@ -549,7 +549,7 @@ NewGame():
             // Clear the game board
             cpy from, #ResetBoard
             cpy to, #GameBoard
-.initBoardLoop    
+.initBoardLoop:
             cpy *to, *from
             add to, #2
             add from, #2
@@ -583,7 +583,7 @@ NewGame():
             pop NextPiece3
             ret
 
-.newGameSound  dw 0x020c
+.newGameSound:  dw 0x020c
             dw WavNewGame
 
 CreatePiece():
@@ -610,7 +610,7 @@ CreatePiece():
             pop valid
             jne done
             cpy Piece, #255
-.done            
+.done:
             ret
 
 IsValid(valid word):
@@ -638,7 +638,7 @@ IsValid(valid word):
 
             cpy i, #1
             cpy mask, #1
-.loop           
+.loop:
             cpy t1, block
             and t1, mask
             jeq row
@@ -654,25 +654,25 @@ IsValid(valid word):
             jeq row
             cpy valid, #0
             ret
-.row
+.row:
             cmp i, #4
             jeq horiz
             cmp i, #8
             jeq horiz
             cmp i, #12
             jne vert
-.horiz
+.horiz:
             sub bx, #3
             inc by
             jmp endloop
-.vert
+.vert:
             inc bx
-.endloop
+.endloop:
             mul mask, #2
             inc i
             cmp i, #15
             jlt loop
-.done
+.done:
             cpy valid, #1
             ret
 
@@ -691,11 +691,11 @@ UpdateGame():
             cmp PieceX, #33
             jlt checkRight
             sub PieceX, #8
-.checkRight
+.checkRight:
             cmp KeyLDown, #1
             jne bumpY
             add PieceX, #8
-.bumpY
+.bumpY:
             cpy t1, Level
             mul t1, #3
             add t1, #2
@@ -704,12 +704,12 @@ UpdateGame():
             cmp KeyKDown, #1
             jne checkSpace
             add PieceY, #54
-.checkSpace            
+.checkSpace:
             cmp KeySpaceDown, #0
             jne rotate
             cpy SpaceWait, #0
             jmp checkValid
-.rotate
+.rotate:
             cmp SpaceWait, #0
             jne checkValid
             cpy SpaceWait, #1
@@ -717,7 +717,7 @@ UpdateGame():
             cmp Rotation, #4
             jlt checkValid
             cpy Rotation, #0
-.checkValid 
+.checkValid:
             psh #0
             jsr IsValid
             pop t1
@@ -734,23 +734,23 @@ UpdateGame():
             jsr StampyTown
             jsr CollapseRows
             jmp done
-.invalid2
+.invalid2:
             cmp PieceX, oldx
             jeq else
             cmp Rotation, oldr
             jeq else
             cpy PieceX, oldx
             jmp checkValid
-.else
+.else:
             cmp Rotation, oldr
             jeq movingOn
             // todo: play sound then fall through
-.movingOn
+.movingOn:
             cpy PieceX, oldx
             cpy Rotation, oldr
             cmp PieceY, oldy
             jne checkValid
-.done            
+.done:
             ret
 
 StampyTown():
@@ -780,7 +780,7 @@ StampyTown():
 
             cpy i, #1
             cpy mask, #1
-.loop           
+.loop:
             cpy t1, block
             and t1, mask
             jeq row
@@ -794,20 +794,20 @@ StampyTown():
             add ptr, #GameBoard
             cpy *ptr, Piece
             inc *ptr
-.row
+.row:
             cmp i, #4
             jeq horiz
             cmp i, #8
             jeq horiz
             cmp i, #12
             jne vert
-.horiz
+.horiz:
             sub bx, #3
             inc by
             jmp endloop
-.vert
+.vert:
             inc bx
-.endloop
+.endloop:
             mul mask, #2
             inc i
             cmp i, #15
@@ -816,7 +816,7 @@ StampyTown():
             // todo bonus time
             ret
 
-.dropSound  dw 0x020c
+.dropSound:  dw 0x020c
             dw WavDropBlock
 
 CollapseRows():
@@ -832,7 +832,7 @@ var t1          word
             cpy by, PieceY
             div by, #COORD_SCALE
             cpy j, #0
-.loop           
+.loop:
             cmp by, #24
             jeq updateScore
 
@@ -843,7 +843,7 @@ var t1          word
             add ptr, #GameBoard
             add ptr, #2         // skip left column
             cpy i, #10
-.countLoop  
+.countLoop:
             cmp *ptr, #0
             jeq nextRow
             add ptr, #2          
@@ -861,9 +861,9 @@ var t1          word
             add t1, #GameBoard
             add t1, #2       
             cpy k, by           // loop from by to 2 step -1  
-.collapseLoop
+.collapseLoop:
             cpy i, #10
-.copyRow
+.copyRow:
             cpy *ptr, *t1
             add ptr, #2
             add t1, #2
@@ -874,17 +874,17 @@ var t1          word
             dec k
             cmp k, #2
             jge collapseLoop
-.nextRow
+.nextRow:
             inc by
             inc j
             cmp j, #4
             jge updateScore
             jmp loop
-.updateScore
+.updateScore:
             cmp total_line, #1
             jlt noscore
             cpy IO_REQUEST, #lineSound
-.noscore
+.noscore:
             cpy ptr, total_line
             mul ptr, #2
             add ptr, #LineScoreTable
@@ -896,12 +896,12 @@ var t1          word
             jlt done
             inc Level
             cpy IO_REQUEST, #levelUpSound
-.done            
+.done:
             ret
 
-.lineSound dw 0x020c
+.lineSound: dw 0x020c
             dw WavLineScore
-.levelUpSound dw 0x020c
+.levelUpSound: dw 0x020c
             dw WavLevelUp
 
 DrawPiece(x word, y word, piece word, rotation word):
@@ -928,7 +928,7 @@ DrawPiece(x word, y word, piece word, rotation word):
 
             cpy i, #1
             cpy mask, #1
-.loop           
+.loop:
             cpy t1, block
             and t1, mask
             jeq row
@@ -936,30 +936,30 @@ DrawPiece(x word, y word, piece word, rotation word):
             cpy fillX, x
             cpy fillY, y
             cpy IO_REQUEST, #fillRect
-.row
+.row:
             cmp i, #4
             jeq horiz
             cmp i, #8
             jeq horiz
             cmp i, #12
             jne vert
-.horiz
+.horiz:
             sub x, #CELL_SIZE*3
             add y, #CELL_SIZE
             jmp endloop
-.vert
+.vert:
             add x, #CELL_SIZE
-.endloop
+.endloop:
             mul mask, #2
             inc i
             cmp i, #15
             jlt loop
-.done
+.done:
             ret
 
-.fillRect   dw 0x0208
-.fillX      dw 0
-.fillY      dw 0
+.fillRect:   dw 0x0208
+.fillX:      dw 0
+.fillY:      dw 0
             dw CELL_SIZE-2
             dw CELL_SIZE-2
 
@@ -998,12 +998,12 @@ DrawPieces():
             cmp t1, PieceDX
             jge incdx
             sub PieceDX, #8
-.incdx            
+.incdx:
             // if dx < (px / COORD_SCALE * COORD_SCALE) then dx = dx + 32
             cmp PieceDX, t1
             jge draw1
             add PieceDX, #8
-.draw1
+.draw1:
             // x = dx * CELL_SIZE / COORD_SCALE + BOARD_LEFT
             // y = py * CELL_SIZE / COORD_SCALE + BOARD_TOP - CELL_SIZE - 1
             cpy t1, PieceDX

--- a/example/branch.s
+++ b/example/branch.s
@@ -12,7 +12,7 @@ fill_memory(start word, end word, value word):
     var ptr word
 
     cpy ptr, start
-.loop
+.loop:
     cpy *ptr, value
     inc ptr
     cmp ptr, end
@@ -21,5 +21,5 @@ fill_memory(start word, end word, value word):
     db 0
     db 0
     db 0
-.skip
+.skip:
     ret

--- a/example/fixed.s
+++ b/example/fixed.s
@@ -39,22 +39,22 @@ printfp(value word):
             and t1, #0b_1000
             jeq b2
             add fraction, #5000
-.b2
+.b2:
             cpy t1, value
             and t1, #0b_0100
             jeq b1            
             add fraction, #2500
-.b1
+.b1:
             cpy t1, value
             and t1, #0b_0010
             jeq b0
             add fraction, #1250
-.b0
+.b0:
             cpy t1, value
             and t1, #0b_0001
             jeq printit
             add fraction, #625
-.printit
+.printit:
             cpy fracbuf, #0x3030
             cpy fracbuf+2, #0x3030
             psh fraction
@@ -64,12 +64,12 @@ printfp(value word):
             pop #6
             cpy 6, #ioPrintFrac
             ret
-.ioPrintDec
+.ioPrintDec:
         dw 0x0101   // stdout putchars
         dw dec        // pointer to zero terminated string
-.dec    db '.', 0x00
+.dec:    db '.', 0x00
 
-.ioPrintFrac
+.ioPrintFrac:
         dw 0x0101   // stdout putchars
         dw fracbuf       // pointer to zero terminated string
-.fracbuf ds 5
+.fracbuf: ds 5

--- a/example/fixed.s
+++ b/example/fixed.s
@@ -1,7 +1,7 @@
 // Testing 12.4 fixed point math, with a print routine to debug.
 
-            import "stdio"
-            import "sqrt"
+            include "stdio.s"
+            include "sqrt.s"
 
             org 0
             dw main

--- a/example/graphics.s
+++ b/example/graphics.s
@@ -12,7 +12,7 @@ main():
     // Initialize main window
     cpy IO_REQUEST, #io_window_req
 
-.loop
+.loop:
     // poll for events until no more
     cpy IO_REQUEST, #io_poll_req
     cmp io_poll_event, #0
@@ -23,7 +23,7 @@ main():
 
     // Draw random colored rectangles
     cpy i, #20
-.draw_rects
+.draw_rects:
     jsr RandomFilledRect
     dec i
     jne draw_rects
@@ -31,30 +31,30 @@ main():
     cpy IO_REQUEST, #io_present_req
     jmp loop
 
-.io_window_req
+.io_window_req:
     dw 0x0201
     dw 640  // width
     dw 480  // height
     dw window_title
-.window_title
+.window_title:
     db "Hello World, from MPU!", 0
 
-.io_poll_req
+.io_poll_req:
     dw 0x0202
-.io_poll_event
+.io_poll_event:
     dw 2
-.io_poll_time
+.io_poll_time:
     dw 2
     ds 8 // space for event data
 
-.io_present_req
+.io_present_req:
     dw 0x0203
     dw 16 // delay ms
 
-.io_sdl_clear
+.io_sdl_clear:
     dw 0x0204
 
-.io_sdl_setcolor
+.io_sdl_setcolor:
     dw 0x0205
     db 0,0,0,255
 
@@ -126,14 +126,14 @@ RandomFilledRect():
     cpy IO_REQUEST, #rect
     ret
 
-.color      dw 0x0205
-.color_r    db 0
-.color_g    db 0
-.color_b    db 0
-.color_a    db 255
+.color:      dw 0x0205
+.color_r:    db 0
+.color_g:    db 0
+.color_b:    db 0
+.color_a:    db 255
 
-.rect       dw 0x0208
-.rect_x     dw 0
-.rect_y     dw 0
-.rect_w     dw 0
-.rect_h     dw 0
+.rect:       dw 0x0208
+.rect_x:     dw 0
+.rect_y:     dw 0
+.rect_w:     dw 0
+.rect_h:     dw 0

--- a/example/lcd.s
+++ b/example/lcd.s
@@ -43,7 +43,7 @@ ty:         dw 0                // Text next print y coordinate
 DrawString(pstring word):
     var ch word
             cpy ch, #0
-.loop
+.loop:
             seb
             cpy ch, *pstring
             jeq done
@@ -54,7 +54,7 @@ DrawString(pstring word):
             cpy tx, #0
             add ty, #LCD_LINE_SPACE
             jmp next
-.validate
+.validate:
             cmp ch, #32
             jlt next
             cmp ch, #128
@@ -64,10 +64,10 @@ DrawString(pstring word):
             psh ch
             jsr DrawCharacter            
             pop #2
-.next
+.next:
             inc pstring
             jmp loop
-.done
+.done:
             clb
             ret
 
@@ -83,13 +83,13 @@ DrawCharacter(char word):
             add lcd, #CharacterTable
             cpy mask, *lcd
             cpy segptr, #CharacterSegmentTable
-.loop
+.loop:
             cpy test, #1
             and test, mask
             jne draw
             add segptr, #8
             jmp next
-.draw
+.draw:
             cpy line_x, tx
             add line_x, *segptr
             add segptr, #2
@@ -106,18 +106,18 @@ DrawCharacter(char word):
             add line_y2, *segptr
             add segptr, #2
             cpy LIBLCD_IO_REQ, #line
-.next
+.next:
             div mask, #2        // shift right
             jne loop            // if result is zero there's nothing more to draw
 
             add tx, #LCD_CHAR_SPACE
             ret
 
-.line       dw 0x0206
-.line_x     dw 0
-.line_y     dw 0
-.line_x2    dw 0
-.line_y2    dw 0
+.line:       dw 0x0206
+.line_x:     dw 0
+.line_y:     dw 0
+.line_x2:    dw 0
+.line_y2:    dw 0
 
 CharacterSegmentTable:
     .cw          = LCD_CHAR_WIDTH

--- a/example/lcd_test.s
+++ b/example/lcd_test.s
@@ -1,6 +1,6 @@
 // Test driver for lcd
 
-            import "lcd"
+            include "lcd.s"
 
             dw main
 

--- a/example/lcd_test.s
+++ b/example/lcd_test.s
@@ -29,12 +29,12 @@ quit:               dw 0
 main():
             // Open the main window
             jsr InitScreen
-.loop
+.loop:
             jsr PollEvents
             jsr DrawScreen
             cmp quit, #0
             jeq loop
-.exit        
+.exit:
             // Main doesn't return, it just halts.
             hlt
 
@@ -45,47 +45,47 @@ InitScreen():
             cpy REG_IO_REQ, #init
             ret
 
-.init       dw 0x0201              // graphics, initialize
+.init:       dw 0x0201              // graphics, initialize
             dw SCREEN_WIDTH
             dw SCREEN_HEIGHT
             dw title
-.title      db "MPU LCD", 0
+.title:      db "MPU LCD", 0
 
 //
 // Poll and handle all pending graphics events, return 1 if time to exit.
 //
 PollEvents():
-.loop
+.loop:
             cpy REG_IO_REQ, #poll
             cmp poll_event, #SDL_QUIT
             jne isKeyDown
             cpy quit, #1
             jmp exit
-.isKeyDown
+.isKeyDown:
             cmp poll_event, #SDL_KEYDOWN
             jne isKeyUp
             psh keycode
             jsr onKeyDown
             pop #2
             jmp loop
-.isKeyUp
+.isKeyUp:
             cmp poll_event, #SDL_KEYUP
             jne isNoMore
             psh keycode
             jsr onKeyUp
             pop #2
             jmp loop
-.isNoMore
+.isNoMore:
             cmp poll_event, #0
             jne loop
-.exit            
+.exit:
             ret
 
-.poll       dw 0x0202           // graphics, poll        
-.poll_event dw 0                // space for response event type id
-.poll_time  dw 0                // space for response event timestamp (1/4 second since init)
-.keycode
-.poll_data  ds 8                // space for response, structure depends on event type
+.poll:       dw 0x0202           // graphics, poll
+.poll_event: dw 0                // space for response event type id
+.poll_time:  dw 0                // space for response event timestamp (1/4 second since init)
+.keycode:
+.poll_data:  ds 8                // space for response, structure depends on event type
 
 //
 // Handle keydown events.
@@ -94,7 +94,7 @@ onKeyDown(keycode word):
             cmp keycode, #SDLK_ESCAPE
             jne done
             cpy quit, #1
-.done            
+.done:
             ret
 
 //
@@ -122,27 +122,27 @@ DrawScreen():
             ret
 
             // device request to set color
-.color      dw 0x0205
-.color_r    db 0
-.color_g    db 0
-.color_b    db 0
-.color_a    db 255
+.color:      dw 0x0205
+.color_r:    db 0
+.color_g:    db 0
+.color_b:    db 0
+.color_a:    db 255
 
             // device request to clear screen
-.clear      dw 0x0204              
+.clear:      dw 0x0204
 
             // device request to present backbuffer to screen
-.present    dw 0x0203              
+.present:    dw 0x0203
             dw 10               // delay ms
-.white      dw 0x0205
+.white:      dw 0x0205
             db 255,0,0,255
-.line       dw 0x0206
+.line:       dw 0x0206
             dw SCREEN_WIDTH / 2
             dw 0
             dw SCREEN_WIDTH / 2
             dw SCREEN_HEIGHT
 
-.sample  db " !\"#$%&'()*+,-./",10
+.sample:  db " !\"#$%&'()*+,-./",10
          db "0123456789:;<=>?@",10
          db "ABCDEFGHIJKLMNOPQRSTUVWXYZ",10
          db "[\\]^_`",10

--- a/example/pong.s
+++ b/example/pong.s
@@ -22,9 +22,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-            import "random"
-            import "lcd"
-            import "strconv"
+            include "random.s"
+            include "lcd.s"
+            include "strconv.s"
 
                 // The initial program counter needs to point to the entry point at startup.
                 // The rest of the special mem area ($00-$0f) can be left zero on startup.

--- a/example/pong.s
+++ b/example/pong.s
@@ -97,12 +97,12 @@ press_space_msg:    db "1=1 PLAYER, 2=2 PLAYERS",0
 main():
             // Open the main window
             jsr InitScreen
-.loop
+.loop:
             jsr PollEvents
             jsr DrawScreen
             cmp quit, #0
             jeq loop
-.exit        
+.exit:
             // Main doesn't return, it just halts.
             hlt
 
@@ -113,47 +113,47 @@ InitScreen():
             cpy REG_IO_REQ, #init
             ret
 
-.init       dw 0x0201
+.init:       dw 0x0201
             dw SCREEN_WIDTH
             dw SCREEN_HEIGHT
             dw title
-.title      db "MPU PONG", 0
+.title:     db "MPU PONG", 0
 
 //
 // Poll and handle all pending graphics events, return 1 if time to exit.
 //
 PollEvents():
-.loop
+.loop:
             cpy REG_IO_REQ, #poll
             cmp poll_event, #SDL_QUIT
             jne isKeyDown
             cpy quit, #1
             jmp exit
-.isKeyDown
+.isKeyDown:
             cmp poll_event, #SDL_KEYDOWN
             jne isKeyUp
             psh keycode
             jsr onKeyDown
             pop #2
             jmp loop
-.isKeyUp
+.isKeyUp:
             cmp poll_event, #SDL_KEYUP
             jne isNoMore
             psh keycode
             jsr onKeyUp
             pop #2
             jmp loop
-.isNoMore
+.isNoMore:
             cmp poll_event, #0
             jne loop
-.exit            
+.exit:
             ret
 
-.poll       dw 0x0202           // graphics, poll        
-.poll_event dw 0                // space for response event type id
-.poll_time  dw 0                // space for response event timestamp (1/4 second since init)
-.keycode
-.poll_data  ds 8                // space for response, structure depends on event type
+.poll:       dw 0x0202           // graphics, poll
+.poll_event: dw 0                // space for response event type id
+.poll_time:  dw 0                // space for response event timestamp (1/4 second since init)
+.keycode:
+.poll_data:  ds 8                // space for response, structure depends on event type
 
 //
 // Handle keydown events.
@@ -163,38 +163,38 @@ onKeyDown(keycode word):
             jne checkZ
             cpy player1_paddle_up, #1
             jmp done
-.checkZ
+.checkZ:
             cmp keycode, #SDLK_z
             jne checkEsc
             cpy player1_paddle_dn, #1
             jmp done            
-.checkEsc  
+.checkEsc:
             cmp keycode, #SDLK_ESCAPE
             jne checkl
             cpy quit, #1
             jmp done
-.checkl
+.checkl:
             cmp keycode, #SDLK_l
             jne checkComma
             cpy player2_paddle_up, #1
             jmp done
-.checkComma
+.checkComma:
             cmp keycode, #SDLK_COMMA
             jne check1
             cpy player2_paddle_dn, #1
             jmp done
-.check1
+.check1:
             cmp keycode, #SDLK_1
             jne check2
             cpy players, #1
             jsr NewGame
             jmp done
-.check2
+.check2:
             cmp keycode, #SDLK_2
             jne done
             cpy players, #2
             jsr NewGame
-.done            
+.done:
             ret
 
 //
@@ -205,19 +205,19 @@ onKeyUp(keycode word):
             jne checkZ
             cpy player1_paddle_up, #0
             jmp done
-.checkZ
+.checkZ:
             cmp keycode, #SDLK_z
             jne checkl
             cpy player1_paddle_dn, #0
-.checkl
+.checkl:
             cmp keycode, #SDLK_l
             jne checkComma
             cpy player2_paddle_up, #0
-.checkComma
+.checkComma:
             cmp keycode, #SDLK_COMMA
             jne done
             cpy player2_paddle_dn, #0
-.done            
+.done:
             ret
 
 //
@@ -232,7 +232,7 @@ NewGame():
             cpy player1_score, #0
             cpy player2_score, #0
             jsr InitBall
-.done
+.done:
             ret
 
 //
@@ -258,7 +258,7 @@ DrawScreen():
             jsr Player2AI
             jmp done
 
-.not_playing
+.not_playing:
             // Show GAME OVER
             cpy tx, #215
             cpy ty, #80
@@ -272,26 +272,26 @@ DrawScreen():
             pop #2
 
             // Present what we've drawn and pause 16ms
-.done            
+.done:
             cpy REG_IO_REQ, #present
             ret
 
             // device request to set color
-.color      dw 0x0205
-.color_r    db 0
-.color_g    db 0
-.color_b    db 0
-.color_a    db 255
+.color:      dw 0x0205
+.color_r:    db 0
+.color_g:    db 0
+.color_b:    db 0
+.color_a:    db 255
 
             // device request to clear screen
-.clear      dw 0x0204
+.clear:      dw 0x0204
 
             // device request to present backbuffer to screen
-.present    dw 0x0203
+.present:    dw 0x0203
             dw 10               // delay ms
-.white      dw 0x0205
+.white:      dw 0x0205
             db 255,255,255,255
-.line       dw 0x0206
+.line:       dw 0x0206
             dw SCREEN_WIDTH / 2
             dw 0
             dw SCREEN_WIDTH / 2
@@ -319,7 +319,7 @@ DrawPlayer1Paddle():
             jge move_done
             cpy player1_paddle_y, #0
             jmp move_done
-.check_down
+.check_down:
             cmp player1_paddle_dn, #0            
             jeq move_done
             clc
@@ -327,19 +327,19 @@ DrawPlayer1Paddle():
             cmp player1_paddle_y, #SCREEN_HEIGHT - PADDLE_HEIGHT
             jlt move_done
             cpy player1_paddle_y, #SCREEN_HEIGHT - PADDLE_HEIGHT
-.move_done                        
+.move_done:
             ret
 
             // device request to set color
-.color      dw 0x0205
+.color:      dw 0x0205
             db 255,255,255,255
 
             // device request to fill rectangle
-.rect       dw 0x0208
-.rect_x     dw 0
-.rect_y     dw 0
-.rect_w     dw 0
-.rect_h     dw 0
+.rect:       dw 0x0208
+.rect_x:     dw 0
+.rect_y:     dw 0
+.rect_w:     dw 0
+.rect_h:     dw 0
 
 //
 // Draw player 2 paddle.
@@ -363,7 +363,7 @@ DrawPlayer2Paddle():
             jge move_done
             cpy player2_paddle_y, #0
             jmp move_done
-.check_down
+.check_down:
             cmp player2_paddle_dn, #0            
             jeq move_done
             clc
@@ -371,19 +371,19 @@ DrawPlayer2Paddle():
             cmp player2_paddle_y, #SCREEN_HEIGHT - PADDLE_HEIGHT
             jlt move_done
             cpy player2_paddle_y, #SCREEN_HEIGHT - PADDLE_HEIGHT
-.move_done                        
+.move_done:
             ret
 
             // device request to set color
-.color      dw 0x0205
+.color:      dw 0x0205
             db 255,255,255,255
 
             // device request to fill rectangle
-.rect       dw 0x0208
-.rect_x     dw 0
-.rect_y     dw 0
-.rect_w     dw 0
-.rect_h     dw 0
+.rect:       dw 0x0208
+.rect_x:     dw 0
+.rect_y:     dw 0
+.rect_w:     dw 0
+.rect_h:     dw 0
 
 //
 // InitBall
@@ -412,7 +412,7 @@ InitBall():
             and isLeft, #1
             jeq setYSpeed
             mul ball_xspeed, #-1
-.setYSpeed
+.setYSpeed:
             // Set yspeed between -3...3
             psh #0
             psh #7
@@ -443,9 +443,9 @@ DrawBall():
             jlt y_bounce
             cmp ball_y, #(SCREEN_HEIGHT - BALL_RADIUS)
             jlt y_no_bounce
-.y_bounce
+.y_bounce:
             mul ball_yspeed, #-1
-.y_no_bounce
+.y_no_bounce:
             // If ball off screen, re-initialize
             cmp ball_x, #-BALL_RADIUS
             jlt player2_scored
@@ -459,13 +459,13 @@ DrawBall():
             jne exitGameOver
             jsr InitBall
             jmp no_reset
-.player2_scored
+.player2_scored:
             inc player2_score
             jsr IsGameOver
             cmp game_over, #0
             jne exitGameOver
             jsr InitBall                                    
-.no_reset            
+.no_reset:
             // Move ball
             clc
             add ball_x, ball_xspeed
@@ -473,19 +473,19 @@ DrawBall():
             add ball_y, ball_yspeed
 
             jsr BounceBall      // Bounce ball off player paddles
-.exitGameOver
+.exitGameOver:
             ret
 
             // device request to set color
-.color      dw 0x0205
+.color:      dw 0x0205
             db 255,255,255,255
 
             // device request to fill rectangle
-.rect       dw 0x0208
-.rect_x     dw 100
-.rect_y     dw 100
-.rect_w     dw 50
-.rect_h     dw 50
+.rect:       dw 0x0208
+.rect_x:     dw 100
+.rect_y:     dw 100
+.rect_w:     dw 50
+.rect_h:     dw 50
 
 //
 // Game over when one player hits at least 11 and is +2 over the other player.
@@ -502,16 +502,16 @@ IsGameOver():
             cmp t1, #2
             jlt done
             jmp over
-.player2Higher
+.player2Higher:
             cmp player2_score, #11
             jlt done
             cpy t1, player2_score
             sub t1, player1_score
             cmp t1, #2
             jlt done
-.over            
+.over:
             cpy game_over, #1
-.done
+.done:
             ret
 
 BounceBall():
@@ -537,7 +537,7 @@ BounceBall():
             mul ball_xspeed, #-1
             jmp done
 
-.check_player2
+.check_player2:
             // Ball collidding with paddle2?  Only check if the ball is going in that direction.
             cmp ball_xspeed, #0
             jlt done
@@ -556,7 +556,7 @@ BounceBall():
             pop overlap
             jeq done
             mul ball_xspeed, #-1
-.done
+.done:
             ret
 
 //
@@ -570,15 +570,15 @@ Player2AI():
             cmp ball_y, middle
             jlt move_up
             jeq no_move
-.move_dn
+.move_dn:
             cpy player2_paddle_dn, #1
             cpy player2_paddle_up, #0
             ret
-.move_up
+.move_up:
             cpy player2_paddle_dn, #0
             cpy player2_paddle_up, #1
             ret
-.no_move       
+.no_move:
             cpy player2_paddle_dn, #0
             cpy player2_paddle_up, #0
             ret
@@ -615,7 +615,7 @@ Overlap(overlap word, x1 word, y1 word, w1 word, h1 word, x2 word, y2 word, w2 w
             cmp right1, x2      // r1 tot left of r2?
             jlt done
             cpy overlap, #1     // If its not all of the above, its overlapping
-.done
+.done:
             ret
 
 //
@@ -650,4 +650,4 @@ PrintInteger(value word):
         pop #2
         ret
 
-.buffer ds 12       // max 10 digits + null ... plus 2 extra cuz I got a bug somewhere's
+.buffer: ds 12       // max 10 digits + null ... plus 2 extra cuz I got a bug somewhere's

--- a/example/random_test.s
+++ b/example/random_test.s
@@ -1,9 +1,9 @@
 //---------------------------------------------------------
 //  Print a random number between 0 and 100.
 //---------------------------------------------------------
-        import "stdio"
-        import "strconv"
-        import "random"
+        include "stdio.s"
+        include "strconv.s"
+        include "random.s"
         
 		dw main
 

--- a/example/sqrt.s
+++ b/example/sqrt.s
@@ -13,13 +13,13 @@ sqrt(res word, n word):
             cpy x, n
             cpy c, #0
             cpy d, #0b0100_0000_0000_0000
-.loop1
+.loop1:
             cmp d, n
             jlt loop2
             jeq loop2
             div d, #4
             jmp loop1
-.loop2
+.loop2:
             cmp d, #0
             jeq done
             cpy t1, c
@@ -30,12 +30,12 @@ sqrt(res word, n word):
             div c, #2
             add c, d
             jmp next
-.else
+.else:
             div c, #2
-.next
+.next:
             div d, #4
             jmp loop2            
-.done
+.done:
             cpy res, c
             ret                        
 

--- a/example/stdio.s
+++ b/example/stdio.s
@@ -1,4 +1,4 @@
-        import "strconv"
+        include "strconv.s"
 
 //
 // Print the word passed on the stack to stdout in decimal.

--- a/example/stdio.s
+++ b/example/stdio.s
@@ -13,19 +13,19 @@ PrintInteger(value word):
         pop #2
         cpy 6, #ioPrintReq
         ret
-.ioPrintReq
+.ioPrintReq:
         dw 0x0101   // stdout putchars
         dw 0        // pointer to zero terminated string
 .BUFSIZE    =   7
-.buffer ds BUFSIZE
+.buffer: ds BUFSIZE
 
 Println():
         cpy 6, #ioPrintReq
         ret
-.ioPrintReq
+.ioPrintReq:
         dw 0x0101   // stdout putchars
         dw lf        // pointer to zero terminated string
-.lf     db 0x0a, 0x00
+.lf:     db 0x0a, 0x00
 
 //
 // Print the given value as a 4-digit hexadecimal number.
@@ -56,10 +56,10 @@ PrintHex(hi byte, lo byte):
                 clb
                 cpy 6, #ioPrintReq
                 ret
-.ioPrintReq
+.ioPrintReq:
                 dw 0x0101       // stdout putchars
                 dw buffer       // pointer to zero terminated string
-.buffer         db "0x0000", 0
+.buffer:         db "0x0000", 0
 
 ToHex(value word):
                 and value, #0x0f
@@ -68,5 +68,5 @@ ToHex(value word):
                 sub value, #0x0a
                 add value, #'a'
                 ret
-.number         add value, #'0'
+.number:         add value, #'0'
                 ret

--- a/example/stdio_test.s
+++ b/example/stdio_test.s
@@ -16,7 +16,7 @@ main():
         var i word
 
         cpy i, #1
-.loop
+.loop:
         psh i
         jsr PrintInteger
         pop #2

--- a/example/stdio_test.s
+++ b/example/stdio_test.s
@@ -1,5 +1,5 @@
-        import "stdio"
-        import "strconv"
+        include "stdio.s"
+        include "strconv.s"
 
 // requires: strconv, stdio
 //---------------------------------------------------------

--- a/example/strconv.s
+++ b/example/strconv.s
@@ -15,7 +15,7 @@ Itoa(value word, buffer word, bsize word):
         add buffer, bsize // start at right side of buffer
         dec buffer
         cpy *buffer, #0
-.loop
+.loop:
         cmp value, #10
         jlt last
         dec buffer
@@ -33,7 +33,7 @@ Itoa(value word, buffer word, bsize word):
         clb
         cpy value, next
         jmp loop
-.last
+.last:
         dec buffer
         clc
         cpy t2, #'0'

--- a/example/testbytes.s
+++ b/example/testbytes.s
@@ -11,7 +11,7 @@ main():
 
     cpy p1, #s1
     cpy p2, #s2
-.loop
+.loop:
     seb
     cpy *p2, *p1
     jeq done
@@ -19,6 +19,6 @@ main():
     inc p1
     inc p2
     jmp loop
-.done
+.done:
     clb
     hlt

--- a/machine/encoding.go
+++ b/machine/encoding.go
@@ -135,6 +135,7 @@ type Encoding struct {
 	Instruction Encoding Table
 
 The main 9 instructions (add, sub, mul, div, and, or, xor, cpy, cmp) support 20 modes:
+
 	Abs,Abs     Ind,Abs     Rel,Abs     RelInd,Abs
 	Abs,Imm     Ind,Imm     Rel,Imm		RelInd,Imm
 	Abs,Ind     Ind,Ind     Rel,Ind		RelInd,Ind
@@ -146,7 +147,6 @@ The 8 jump instructions only support immediate mode.
 There are 5 instructions with implied mode.
 
 Push supports all 5 modes.  Pop with immediate value pops and discards that number of bytes.
-
 */
 var opTable = []Encoding{
 	0x00: {op: Hlt, m1: Implied, m2: Implied},

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -41,18 +41,18 @@ type AssertionFailure struct {
 // Machine implements MPU ... memory processing unit.
 // It supports 27 instructions and 6 addressing modes.
 type Machine struct {
-	memory         Memory // 64kb of memory + dma overlay
-	pc             uint16 // program counter ... shadowed on read/write to address $0
-	sp             uint16 // stack pointer ... shadowed on read/write to address $2
-	fp             uint16 // frame pointer ... shadowed on read/write to address $4
-	negative       bool   // Negative flag, set true if last value had the high bit set.
-	zero           bool   // Zero flag, set true if last value had zero value.
-	carry          bool   // Carry flag
-	bytes          bool   // Bytes flag, if true then operations are on bytes instead of words
-	step           bool   // Single step mode, if true breaks after executing 1 instruction
-	assertion      bool   // Assertion flag, set by SEA instruction, affects next CMP
-	testMode       bool   // Test mode, enables assertion checking
-	assertionFails int    // Count of assertion failures
+	memory         Memory            // 64kb of memory + dma overlay
+	pc             uint16            // program counter ... shadowed on read/write to address $0
+	sp             uint16            // stack pointer ... shadowed on read/write to address $2
+	fp             uint16            // frame pointer ... shadowed on read/write to address $4
+	negative       bool              // Negative flag, set true if last value had the high bit set.
+	zero           bool              // Zero flag, set true if last value had zero value.
+	carry          bool              // Carry flag
+	bytes          bool              // Bytes flag, if true then operations are on bytes instead of words
+	step           bool              // Single step mode, if true breaks after executing 1 instruction
+	assertion      bool              // Assertion flag, set by SEA instruction, affects next CMP
+	testMode       bool              // Test mode, enables assertion checking
+	assertionFails int               // Count of assertion failures
 	lastFailure    *AssertionFailure // Details of the last assertion failure
 }
 
@@ -104,7 +104,7 @@ func (m *Machine) Run() {
 		value1 := 0       // value of first operand, if any
 		value2 := 0       // value of second operand, if any
 		opCode, m1, m2 := DecodeOp(in)
-		
+
 		// Check for halt after decoding
 		if opCode == Hlt {
 			return

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -255,23 +255,23 @@ func TestSeaInstruction(t *testing.T) {
 		byte(EncodeOp(Sea, Implied, Implied)), // SEA
 		byte(EncodeOp(Hlt, Implied, Implied)), // HLT
 	}
-	
+
 	// Create machine with proper image (PC at 0x100 by default)
 	image := make([]byte, 0x200)
 	// Set PC to 0x100
 	image[PCAddr] = 0x00
 	image[PCAddr+1] = 0x01
 	copy(image[0x100:], code)
-	
+
 	machine := NewMachine(image)
-	
+
 	// Initially assertion flag should be false
 	assert.False(t, machine.assertion, "Assertion flag should be false initially")
-	
+
 	// Execute SEA instruction
 	machine.step = true
 	machine.Run()
-	
+
 	// Assertion flag should now be true
 	assert.True(t, machine.assertion, "Assertion flag should be true after SEA")
 }
@@ -281,44 +281,44 @@ func TestCmpWithAssertion(t *testing.T) {
 	// Set up memory locations for comparison
 	code := []byte{
 		// Store values at addresses 0x100 and 0x102
-		byte(EncodeOp(Cpy, Absolute, Immediate)),   // CPY 0x100, #5
-		0x00, 0x01, // addr = 0x100
+		byte(EncodeOp(Cpy, Absolute, Immediate)), // CPY 0x100, #5
+		0x00, 0x01,                               // addr = 0x100
 		0x05, 0x00, // value = 5
-		byte(EncodeOp(Cpy, Absolute, Immediate)),   // CPY 0x102, #5
-		0x02, 0x01, // addr = 0x102
+		byte(EncodeOp(Cpy, Absolute, Immediate)), // CPY 0x102, #5
+		0x02, 0x01,                               // addr = 0x102
 		0x05, 0x00, // value = 5
-		
+
 		// First comparison (should pass)
-		byte(EncodeOp(Sea, Implied, Implied)),       // SEA
-		byte(EncodeOp(Cmp, Absolute, Immediate)),    // CMP 0x100, #5
-		0x00, 0x01, // addr = 0x100
+		byte(EncodeOp(Sea, Implied, Implied)),    // SEA
+		byte(EncodeOp(Cmp, Absolute, Immediate)), // CMP 0x100, #5
+		0x00, 0x01,                               // addr = 0x100
 		0x05, 0x00, // value = 5
-		
+
 		// Second comparison (should fail)
-		byte(EncodeOp(Sea, Implied, Implied)),       // SEA
-		byte(EncodeOp(Cmp, Absolute, Immediate)),    // CMP 0x100, #3
-		0x00, 0x01, // addr = 0x100
+		byte(EncodeOp(Sea, Implied, Implied)),    // SEA
+		byte(EncodeOp(Cmp, Absolute, Immediate)), // CMP 0x100, #3
+		0x00, 0x01,                               // addr = 0x100
 		0x03, 0x00, // value = 3
-		
-		byte(EncodeOp(Hlt, Implied, Implied)),       // HLT
+
+		byte(EncodeOp(Hlt, Implied, Implied)), // HLT
 	}
-	
+
 	// Create machine with proper image
 	image := make([]byte, 0x200)
 	// Set PC to 0x100
 	image[PCAddr] = 0x00
 	image[PCAddr+1] = 0x01
 	copy(image[0x100:], code)
-	
+
 	machine := NewMachine(image)
 	machine.EnableTestMode()
-	
+
 	// Run the program
 	machine.Run()
-	
+
 	// First CMP should pass (5 == 5), second should fail (5 != 3)
 	assert.Equal(t, 1, machine.AssertionFailures(), "Should have 1 assertion failure")
-	
+
 	// Assertion flag should be cleared after CMP
 	assert.False(t, machine.assertion, "Assertion flag should be cleared after CMP")
 }
@@ -327,32 +327,32 @@ func TestCmpWithoutAssertion(t *testing.T) {
 	// Test that normal CMP behavior is unchanged without SEA
 	code := []byte{
 		// Store value at address 0x100
-		byte(EncodeOp(Cpy, Absolute, Immediate)),   // CPY 0x100, #5
-		0x00, 0x01, // addr = 0x100
+		byte(EncodeOp(Cpy, Absolute, Immediate)), // CPY 0x100, #5
+		0x00, 0x01,                               // addr = 0x100
 		0x05, 0x00, // value = 5
-		
-		byte(EncodeOp(Cmp, Absolute, Immediate)),   // CMP 0x100, #3
-		0x00, 0x01, // addr = 0x100
+
+		byte(EncodeOp(Cmp, Absolute, Immediate)), // CMP 0x100, #3
+		0x00, 0x01,                               // addr = 0x100
 		0x03, 0x00, // value = 3
-		byte(EncodeOp(Hlt, Implied, Implied)),       // HLT
+		byte(EncodeOp(Hlt, Implied, Implied)), // HLT
 	}
-	
+
 	// Create machine with proper image
 	image := make([]byte, 0x200)
 	// Set PC to 0x100
 	image[PCAddr] = 0x00
 	image[PCAddr+1] = 0x01
 	copy(image[0x100:], code)
-	
+
 	machine := NewMachine(image)
 	machine.EnableTestMode()
-	
+
 	// Run the program
 	machine.Run()
-	
+
 	// No assertion failures expected
 	assert.Equal(t, 0, machine.AssertionFailures(), "Should have no assertion failures")
-	
+
 	// Check that flags are set correctly
 	assert.False(t, machine.zero, "Zero flag should be false (5 != 3)")
 	assert.False(t, machine.negative, "Negative flag should be false (5 - 3 = 2)")

--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func format(inputs []*os.File, rewrite bool) {
 	}
 	lexer := asm.NewLexer(inputs[0].Name(), inputs[0])
 	parser := asm.NewParser(asm.NewInput([]asm.TokenReader{lexer}))
-	parser.SetProcessImport(false)
+	parser.SetProcessInclude(false)
 	parser.Parse()
 	parser.PrintErrors()
 	if parser.HasErrors() {
@@ -246,13 +246,13 @@ func format(inputs []*os.File, rewrite bool) {
 func getInputs(flagSet *flag.FlagSet) []*os.File {
 	var inputs []*os.File
 	args := flagSet.Args()
-	
+
 	if len(args) == 0 {
 		fmt.Fprintf(os.Stderr, "Error: no input files specified\n\n")
 		flagSet.Usage()
 		os.Exit(1)
 	}
-	
+
 	for _, name := range args {
 		f, err := os.Open(name)
 		if err != nil {

--- a/monitor.go
+++ b/monitor.go
@@ -38,13 +38,11 @@ const welcome = `
 `
 
 /*
-
 d/dump [start [end]]
 l/list [start]
 run address
 s/step [address]
 set [address value [value]*]
-
 */
 func (m *Monitor) Run() {
 	fmt.Printf(welcome)

--- a/test/discovery.go
+++ b/test/discovery.go
@@ -50,7 +50,7 @@ func DiscoverTests(statements asm.Statement) (*TestSuite, error) {
 				Line:     s.Line(),
 			}
 			suite.Tests = append(suite.Tests, test)
-			
+
 		case *asm.LabelStatement:
 			// Check for special test setup/teardown functions
 			name := s.Name()

--- a/test/discovery_test.go
+++ b/test/discovery_test.go
@@ -44,11 +44,11 @@ test TestAdd():
 `
 	statements := parseSource(t, source)
 	suite, err := DiscoverTests(statements)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, suite)
 	assert.Len(t, suite.Tests, 1)
-	
+
 	test := suite.Tests[0]
 	assert.Equal(t, "TestAdd", test.Name)
 	assert.Equal(t, "TestAdd", test.Function)
@@ -69,11 +69,11 @@ test TestThree():
 `
 	statements := parseSource(t, source)
 	suite, err := DiscoverTests(statements)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, suite)
 	assert.Len(t, suite.Tests, 3)
-	
+
 	assert.Equal(t, "TestOne", suite.Tests[0].Name)
 	assert.Equal(t, "TestTwo", suite.Tests[1].Name)
 	assert.Equal(t, "TestThree", suite.Tests[2].Name)
@@ -91,7 +91,7 @@ main:
 `
 	statements := parseSource(t, source)
 	suite, err := DiscoverTests(statements)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, suite)
 	assert.Empty(t, suite.Tests)
@@ -118,11 +118,11 @@ test TestAnother():
 `
 	statements := parseSource(t, source)
 	suite, err := DiscoverTests(statements)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, suite)
 	assert.Len(t, suite.Tests, 2)
-	
+
 	assert.Equal(t, "TestHelper", suite.Tests[0].Name)
 	assert.Equal(t, "TestAnother", suite.Tests[1].Name)
 }
@@ -142,7 +142,7 @@ test_teardown:
 `
 	statements := parseSource(t, source)
 	suite, err := DiscoverTests(statements)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, suite)
 	assert.Len(t, suite.Tests, 1)

--- a/test/executor.go
+++ b/test/executor.go
@@ -104,7 +104,7 @@ func (e *TestExecutor) runTest(test TestInfo) TestResult {
 
 	// Call the test function with panic recovery
 	testAddr := uint16(symbol.Value())
-	
+
 	// Recover from panics during test execution
 	func() {
 		defer func() {
@@ -112,7 +112,7 @@ func (e *TestExecutor) runTest(test TestInfo) TestResult {
 				// Find the PC where the error occurred
 				pc := e.machine.Memory().GetWord(machine.PCAddr)
 				file, line := e.findSourceLocation(pc)
-				
+
 				var msg string
 				switch err := r.(type) {
 				case error:
@@ -120,7 +120,7 @@ func (e *TestExecutor) runTest(test TestInfo) TestResult {
 				default:
 					msg = fmt.Sprintf("%v", r)
 				}
-				
+
 				// Store the error for later retrieval
 				e.lastError = &TestResult{
 					Name:    test.Name,
@@ -134,10 +134,10 @@ func (e *TestExecutor) runTest(test TestInfo) TestResult {
 				}
 			}
 		}()
-		
+
 		e.callAddress(testAddr)
 	}()
-	
+
 	// If we caught a panic, return the error result
 	if e.lastError != nil {
 		result := *e.lastError
@@ -166,7 +166,7 @@ func (e *TestExecutor) runTest(test TestInfo) TestResult {
 				Line:     line,
 			})
 		}
-		
+
 		return TestResult{
 			Name:           test.Name,
 			Passed:         false,
@@ -197,7 +197,7 @@ func (e *TestExecutor) callFunction(name string) error {
 	if symbol == nil {
 		return fmt.Errorf("function '%s' not found", name)
 	}
-	
+
 	addr := uint16(symbol.Value())
 	e.callAddress(addr)
 	return nil
@@ -207,16 +207,16 @@ func (e *TestExecutor) callFunction(name string) error {
 func (e *TestExecutor) callAddress(addr uint16) {
 	// Get current PC
 	pc := e.machine.Memory().GetWord(machine.PCAddr)
-	
+
 	// Push return address (current PC + 3 for JSR instruction)
 	sp := e.machine.Memory().GetWord(machine.SPAddr)
 	sp -= 2
 	e.machine.Memory().PutWord(sp, pc+3)
 	e.machine.Memory().PutWord(machine.SPAddr, sp)
-	
+
 	// Jump to test function
 	e.machine.Memory().PutWord(machine.PCAddr, addr)
-	
+
 	// Run until RET
 	e.machine.Run()
 }

--- a/test/executor_test.go
+++ b/test/executor_test.go
@@ -62,7 +62,7 @@ test TestPassing():
 		ret
 `
 	m, symbols, debugInfo := compileAndLoad(t, source)
-	
+
 	suite := &TestSuite{
 		Tests: []TestInfo{{
 			Name:     "TestPassing",
@@ -93,7 +93,7 @@ test TestFailing():
 		ret
 `
 	m, symbols, debugInfo := compileAndLoad(t, source)
-	
+
 	suite := &TestSuite{
 		Tests: []TestInfo{{
 			Name:     "TestFailing",
@@ -134,7 +134,7 @@ test TestFail():
 		ret
 `
 	m, symbols, debugInfo := compileAndLoad(t, source)
-	
+
 	// Discover tests from the source
 	parser := asm.NewParserFromReader("test.s", strings.NewReader(source))
 	parser.Parse()
@@ -146,7 +146,7 @@ test TestFail():
 
 	results := executor.Results()
 	assert.Len(t, results, 3)
-	
+
 	passed, failed := executor.Summary()
 	assert.Equal(t, 2, passed)
 	assert.Equal(t, 1, failed)

--- a/test/formatter.go
+++ b/test/formatter.go
@@ -64,12 +64,12 @@ func (f *TerminalFormatter) Format(results []TestResult, w io.Writer) error {
 			if result.Message != "" && (f.Verbose || strings.Contains(result.Message, "runtime error")) {
 				fmt.Fprintf(w, "  %s\n", result.Message)
 			}
-			
+
 			// Show failure details with source
 			for _, detail := range result.FailureDetails {
 				if detail.File != "" && detail.Line > 0 {
 					fmt.Fprintf(w, "\n  at %s:%d\n", detail.File, detail.Line)
-					
+
 					// Get source lines with context
 					lines, startLine, err := f.sourceReader.GetContext(detail.File, detail.Line, 1, 1)
 					if err == nil {
@@ -87,7 +87,7 @@ func (f *TerminalFormatter) Format(results []TestResult, w io.Writer) error {
 							}
 						}
 					}
-					
+
 					// Only show expected/actual for assertion failures
 					if !strings.Contains(result.Message, "runtime error") {
 						fmt.Fprintf(w, "\n  Expected: %d\n", detail.Expected)

--- a/test/source_reader.go
+++ b/test/source_reader.go
@@ -38,11 +38,11 @@ func (s *SourceReader) GetLine(filename string, lineNum int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	if lineNum < 1 || lineNum > len(lines) {
 		return "", fmt.Errorf("line %d out of range (file has %d lines)", lineNum, len(lines))
 	}
-	
+
 	return lines[lineNum-1], nil
 }
 
@@ -52,21 +52,21 @@ func (s *SourceReader) GetContext(filename string, lineNum int, before, after in
 	if err != nil {
 		return nil, 0, err
 	}
-	
+
 	if lineNum < 1 || lineNum > len(lines) {
 		return nil, 0, fmt.Errorf("line %d out of range", lineNum)
 	}
-	
+
 	start := lineNum - before - 1
 	if start < 0 {
 		start = 0
 	}
-	
+
 	end := lineNum + after
 	if end > len(lines) {
 		end = len(lines)
 	}
-	
+
 	return lines[start:end], start + 1, nil
 }
 
@@ -75,23 +75,23 @@ func (s *SourceReader) getLines(filename string) ([]string, error) {
 	if lines, ok := s.cache[filename]; ok {
 		return lines, nil
 	}
-	
+
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
-	
+
 	var lines []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
-	
+
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	
+
 	s.cache[filename] = lines
 	return lines, nil
 }


### PR DESCRIPTION
## Summary
- Changed `import` statements to `include` for consistency with assembly conventions
- Added colon requirement for local labels to match global label syntax
- Updated all examples and tests to use the new syntax

## Changes
- All label declarations now consistently use colons (both global and local)
- `import "foo"` changed to `include "foo.s"` 
- Updated parser, formatter, and all example files

## Test plan
- [x] All existing tests pass
- [x] Examples compile and run correctly
- [x] Formatter handles new syntax properly

🤖 Generated with [Claude Code](https://claude.ai/code)